### PR TITLE
Fix off-by-one error when expiring all items from ExpiringDict

### DIFF
--- a/expiring_dict/expiringdict.py
+++ b/expiring_dict/expiringdict.py
@@ -31,10 +31,10 @@ class ExpiringDict(MutableMapping):
         with self.__lock:
             for index, (timestamp, key) in enumerate(self.__keys):
                 if timestamp > now:  # rest of the timestamps in future
-                    max_index = index
                     break
                 try:
                     del self.__store[key]
+                    max_index = index + 1
                 except KeyError:
                     pass  # don't care if it was deleted early
             del self.__keys[0:max_index]

--- a/tests/test_expiringdict.py
+++ b/tests/test_expiringdict.py
@@ -42,3 +42,19 @@ def test_dict_ops():
     assert [v for v in d.values()] == [v for v in ed.values()]
     assert [i for i in d.items()] == [i for i in ed.items()]
     assert "one" in ed
+
+
+def test_class_ttl_twice():
+    d = ExpiringDict(ttl=0.01, interval=0.005)
+    d["key"] = "should be gone"
+    assert len(d) == 1
+    sleep(0.006)
+    assert len(d) == 1
+    sleep(0.02)
+    assert len(d) == 0
+    d["key"] = "should be gone"
+    assert len(d) == 1
+    sleep(0.006)
+    assert len(d) == 1
+    sleep(0.02)
+    assert len(d) == 0


### PR DESCRIPTION
Fixes an off-by-one error when all items are expired from the dictionary. If all items are expired in flush(), they were deleted from __store, but the last key is left in __keys. If a new item is added to the ExpiringDict with the same key that was left in the __keys, it would be deleted immediately.

Before:
``` python
>>> from expiring_dict import ExpiringDict
>>> d = ExpiringDict(ttl=20)
>>> d["1"] = "a"
>>> d["2"] = "b"
>>> d["3"] = "c"
>>> list(d.keys())
['1', '2', '3']
>>> d._ExpiringDict__keys
SortedKeyList([(1726283608.126443, '1'), (1726283613.0649834, '2'), (1726283618.1918259, '3')], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f4403366840>)
>>>
>>> # a few seconds later
>>> list(d.keys())
['2', '3']
>>> list(d.keys())
['3']
>>> list(d.keys())
[]
>>> d._ExpiringDict__keys
SortedKeyList([(1726283618.1918259, '3')], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f4403366840>)
>>>
>>> # add "3" back in and it expires immediately
>>> d["3"] = "c"
>>> d._ExpiringDict__keys
SortedKeyList([(1726283756.496043, '3'), (1726283775.3096526, '3')], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f4403366840>)
>>> list(d.keys())
[]
>>>
>>> # a few seconds later
>>> d._ExpiringDict__keys
SortedKeyList([(1726283775.3096526, '3')], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f4403366840>)
```

After:
``` python
>>> from expiring_dict import ExpiringDict
>>> d = ExpiringDict(ttl=20)
>>> d["1"] = "a"
>>> d["2"] = "b"
>>> d["3"] = "c"
>>> list(d.keys())
['1', '2', '3']
>>> d._ExpiringDict__keys
SortedKeyList([(1726284551.5900507, '1'), (1726284555.7984524, '2'), (1726284561.8925157, '3')], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f114a4f6840>)
>>>
>>> # a few seconds later
>>> list(d.keys())
['2', '3']
>>> list(d.keys())
['3']
>>> list(d.keys())
[]
>>> d._ExpiringDict__keys
SortedKeyList([], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f114a4f6840>)
>>>
>>> # add "3" back in
>>> d["3"] = "c"
>>> d._ExpiringDict__keys
SortedKeyList([(1726284699.4399946, '3')], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f114a4f6840>)
>>>
>>> # expires normally 20 seconds later
>>> list(d.keys())
[]
>>> d._ExpiringDict__keys
SortedKeyList([], key=<function ExpiringDict.__init__.<locals>.<lambda> at 0x7f114a4f6840>)
```