### PR TITLE
Reset the ttl for a key when it is updated

### DIFF
--- a/expiring_dict/expiringdict.py
+++ b/expiring_dict/expiringdict.py
@@ -3,7 +3,7 @@ try:
 except ImportError:  # Will allow usage with virtually any python 3 version
     from collections import MutableMapping
 
-from threading import Timer, Thread, Lock
+from threading import Thread, Lock
 from sortedcontainers import SortedKeyList
 from time import time, sleep
 
@@ -63,6 +63,11 @@ class ExpiringDict(MutableMapping):
 
     def __set_with_expire(self, key, value, ttl):
         self.__lock.acquire()
+        if key in self.__store.keys():
+            # remove old entry to reset the ttl
+            for index, (_timestamp, old_key) in enumerate(self.__keys):
+                if old_key == key:
+                    del self.__keys[index]
         self.__keys.add((time() + ttl, key))
         self.__store[key] = value
         self.__lock.release()

--- a/expiring_dict/expiringdict.py
+++ b/expiring_dict/expiringdict.py
@@ -68,6 +68,7 @@ class ExpiringDict(MutableMapping):
             for index, (_timestamp, old_key) in enumerate(self.__keys):
                 if old_key == key:
                     del self.__keys[index]
+                    break  # should only be one entry per key
         self.__keys.add((time() + ttl, key))
         self.__store[key] = value
         self.__lock.release()

--- a/tests/test_expiringdict.py
+++ b/tests/test_expiringdict.py
@@ -58,3 +58,16 @@ def test_class_ttl_twice():
     assert len(d) == 1
     sleep(0.02)
     assert len(d) == 0
+
+
+def test_class_reset_ttl_with_reinsert():
+    d = ExpiringDict(ttl=0.01, interval=0.001)
+    d["key"] = "should be reset"
+    assert len(d) == 1
+    sleep(0.006)
+    assert len(d) == 1
+    d["key"] = "should be reset"
+    sleep(0.006)
+    assert len(d) == 1
+    sleep(0.006)
+    assert len(d) == 0


### PR DESCRIPTION
Resets the TTL of an entry when it gets updated before it has expired.